### PR TITLE
Add support for nvme drives

### DIFF
--- a/bootinfoscript
+++ b/bootinfoscript
@@ -626,7 +626,7 @@ exec 2> ${Error_Log};
 #
 #   Support more than 26 drives.
 
-All_Hard_Drives=$(ls /dev/hd[a-z] /dev/hd[a-z][a-z] /dev/sd[a-z] /dev/sd[a-z][a-z] /dev/xvd[a-z] /dev/vd[a-z] /dev/vd[a-z][a-z] 2>> ${Trash});
+All_Hard_Drives=$(ls /dev/hd[a-z] /dev/hd[a-z][a-z] /dev/sd[a-z] /dev/sd[a-z][a-z] /dev/xvd[a-z] /dev/vd[a-z] /dev/vd[a-z][a-z] /dev/nvme[0-99]n[0-99]p[0-99] 2>> ${Trash});
 
 
 ## Add found RAID disks to list of hard drives. ##


### PR DESCRIPTION
I was happy to find the script but the results where disappointing at first. At some point I realized this was probably due to not checking for my nvme drives. So I added that. and than it worked. I hope you have time to merge it. 
I can't guarantee all nvme drives will be included since I have no real knowledge of their naming convention,... But I'm pretty sure this addition won't break anything either.git@github.com:sudoapt-getclean/bootinfoscript.git